### PR TITLE
Refactor sales save logic into services

### DIFF
--- a/sales/services.py
+++ b/sales/services.py
@@ -1,0 +1,50 @@
+"""Service functions for the ``sales`` app."""
+
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+from django.db import transaction
+
+if TYPE_CHECKING:  # pragma: no cover - for type checking only
+    from .models import SaleItem
+
+
+def calculate_sale_item_price(sale_item: "SaleItem") -> Decimal:
+    """Return the selling price for a ``SaleItem``.
+
+    Parameters
+    ----------
+    sale_item : SaleItem
+        The sale item for which to determine the unit price.
+
+    Returns
+    -------
+    Decimal
+        The ``selling_price`` of the related product.
+    """
+
+    return sale_item.product.selling_price
+
+
+@transaction.atomic
+def update_stock_after_sale(sale_item: "SaleItem") -> None:
+    """Decrement stock based on a saved ``SaleItem``.
+
+    Parameters
+    ----------
+    sale_item : SaleItem
+        The sale item that was saved.
+
+    Returns
+    -------
+    None
+    """
+
+    stock = sale_item.product.stocks.first()
+    if not stock:
+        return
+
+    quantity_difference = sale_item.quantity - getattr(sale_item, "_old_quantity", 0)
+    stock.current_stock -= quantity_difference
+    stock.save()
+

--- a/sales/signals.py
+++ b/sales/signals.py
@@ -16,14 +16,15 @@ def pre_save_sale_item_quantity(sender, instance, **kwargs):
 
 @receiver(post_save, sender=SaleItem)
 def post_save_sale_item_stock_adjustment(sender, instance, created, **kwargs):
-    stock = instance.product.stocks.first()
-    if stock:
-        if created: # New SaleItem created
-            stock.current_stock -= instance.quantity
-        else: # Existing SaleItem updated
-            quantity_difference = instance.quantity - instance._old_quantity
-            stock.current_stock -= quantity_difference
-        stock.save()
+    if not getattr(instance, '_skip_post_save_stock_update', False):
+        stock = instance.product.stocks.first()
+        if stock:
+            if created:  # New SaleItem created
+                stock.current_stock -= instance.quantity
+            else:  # Existing SaleItem updated
+                quantity_difference = instance.quantity - instance._old_quantity
+                stock.current_stock -= quantity_difference
+            stock.save()
 
     # After stock adjustment, update the total amount of the associated Sale
     # This ensures the Sale's total is correct immediately after its SaleItems are saved


### PR DESCRIPTION
## Summary
- introduce `sales/services.py` with helpers for pricing and stock updates
- update `SaleItem.save()` to delegate logic to the service layer
- ensure signals skip duplicate stock updates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68457c8aee3c8333bab79a8d40bb30f4