### PR TITLE
Refactor RepairJob computations

### DIFF
--- a/repairs/admin.py
+++ b/repairs/admin.py
@@ -1,6 +1,7 @@
 # repairs/admin.py
 from django.contrib import admin
 from .models import RepairJob, UsedPart
+from .forms import RepairJobForm
 
 # การตั้งค่าหน้า Admin สำหรับ RepairJob
 class UsedPartInline(admin.TabularInline):
@@ -9,18 +10,27 @@ class UsedPartInline(admin.TabularInline):
     readonly_fields = ('cost_price_per_unit', 'created_at')
 
 class RepairJobAdmin(admin.ModelAdmin):
-    list_display = ('id', 'job_name', 'customer', 'repair_date', 'labor_charge', 
-                   'parts_cost_total', 'total_amount', 'status', 'payment', 'updated_at')
+    form = RepairJobForm
+    list_display = (
+        'id', 'job_name', 'customer', 'repair_date', 'labor_charge',
+        'parts_cost_total', 'total_amount', 'status', 'payment', 'updated_at'
+    )
     search_fields = ('customer__name', 'description', 'notes')
     list_filter = ('status', 'payment', 'repair_date', 'updated_at')
     ordering = ('-updated_at',)
     inlines = [UsedPartInline]
-    readonly_fields = ('total_amount', 'parts_cost_total',)
-
-    def save_model(self, request, obj, form, change):
-        # คำนวณค่า total_amount ก่อนบันทึก
-        obj.total_amount = obj.labor_charge + obj.parts_cost_total
-        super().save_model(request, obj, form, change)
+    readonly_fields = ('labor_charge', 'parts_cost_total')
+    fieldsets = (
+        (None, {
+            'fields': (
+                'job_name', 'customer', 'repair_date', 'description',
+                'total_amount', 'status', 'notes', 'payment'
+            )
+        }),
+        ('Computed', {
+            'fields': readonly_fields
+        }),
+    )
 
 # การตั้งค่าหน้า Admin สำหรับ UsedPart
 class UsedPartAdmin(admin.ModelAdmin):

--- a/repairs/forms.py
+++ b/repairs/forms.py
@@ -1,0 +1,34 @@
+from django import forms
+from .models import RepairJob
+from .services import calculate_parts_cost
+
+class RepairJobForm(forms.ModelForm):
+    total_amount = forms.DecimalField(min_value=0)
+
+    class Meta:
+        model = RepairJob
+        fields = [
+            'job_name',
+            'customer',
+            'repair_date',
+            'description',
+            'status',
+            'notes',
+            'payment',
+        ]
+
+    def save(self, commit=True):
+        self.instance.total_amount = self.cleaned_data['total_amount']
+        return super().save(commit=commit)
+
+    def clean_total_amount(self):
+        total = self.cleaned_data.get('total_amount')
+        parts_cost = sum(
+            calculate_parts_cost(part.product, part.quantity)
+            for part in self.instance.used_parts.all()
+        )
+        if total is not None and total < parts_cost:
+            raise forms.ValidationError(
+                'Total amount must be greater than or equal to the parts cost.'
+            )
+        return total

--- a/repairs/models.py
+++ b/repairs/models.py
@@ -3,7 +3,11 @@ from django.db import models, transaction
 from customers.models import Customer
 from inventory.models import Product
 from repairs.utils.cost_calculation import update_repair_job_costs
-from .services import calculate_repair_total, apply_used_part_cost
+from .services import (
+    apply_used_part_cost,
+    calculate_parts_cost,
+    compute_labor_from_total,
+)
 
 # งานซ่อมหลัก
 class RepairJob(models.Model):
@@ -34,8 +38,17 @@ class RepairJob(models.Model):
 
     @transaction.atomic
     def save(self, *args, **kwargs):
-        # คงไว้ซึ่งตรรกะเดิมโดยเรียก calculate_repair_total
-        self.total_amount = calculate_repair_total(self)
+        from .services import calculate_parts_cost, compute_labor_from_total
+
+        parts = self.used_parts.all() if self.pk else []
+        parts_cost = sum(
+            calculate_parts_cost(up.product, up.quantity)
+            for up in parts
+        )
+
+        self.labor_charge = compute_labor_from_total(self.total_amount, parts_cost)
+        self.parts_cost_total = parts_cost
+
         super().save(*args, **kwargs)
 
     def __str__(self):

--- a/repairs/services.py
+++ b/repairs/services.py
@@ -41,3 +41,15 @@ def apply_used_part_cost(used_part: "UsedPart") -> Decimal:
     cost_per_unit = calculate_historical_weighted_average_cost(used_part.product)
     used_part.cost_price_per_unit = cost_per_unit
     return cost_per_unit * used_part.quantity
+
+
+def calculate_parts_cost(product, quantity=1):
+    """Return Decimal: weighted-average cost per unit * quantity."""
+    from .utils.cost_calculation import calculate_historical_weighted_average_cost
+    unit_cost = calculate_historical_weighted_average_cost(product)
+    return unit_cost * quantity
+
+
+def compute_labor_from_total(total_amount, parts_cost):
+    """Return Decimal: labor charge = total_amount - parts_cost."""
+    return total_amount - parts_cost

--- a/repairs/tests.py
+++ b/repairs/tests.py
@@ -7,6 +7,7 @@ from customers.models import Customer
 from inventory.models import Category, Unit, Product, Supplier, Stock, Purchase
 from repairs.models import RepairJob, UsedPart
 from repairs.utils.cost_calculation import calculate_historical_weighted_average_cost
+from repairs.forms import RepairJobForm
 
 
 class CostCalculationTests(TestCase):
@@ -46,20 +47,88 @@ class CostCalculationTests(TestCase):
 
 class RepairJobModelTests(TestCase):
     def setUp(self):
+        self.category = Category.objects.create(name="Cat")
+        self.unit = Unit.objects.create(name="Unit")
+        self.product = Product.objects.create(
+            name="Prod",
+            category=self.category,
+            unit=self.unit,
+            selling_price=Decimal("100.00"),
+        )
+        self.supplier = Supplier.objects.create(name="Supp", contact_info="c")
+        Purchase.objects.create(
+            product=self.product,
+            quantity=2,
+            price=Decimal("10"),
+            supplier=self.supplier,
+            purchase_date=timezone.now(),
+            payment="PAID",
+            status="RECEIVED",
+        )
+        Purchase.objects.create(
+            product=self.product,
+            quantity=2,
+            price=Decimal("20"),
+            supplier=self.supplier,
+            purchase_date=timezone.now(),
+            payment="PAID",
+            status="RECEIVED",
+        )
         self.customer = Customer.objects.create(
             name="Cust", phone="0", email="c@example.com", address="addr"
         )
 
-    def test_save_calculates_total_amount(self):
+    def test_labor_charge_calculated_from_total(self):
         job = RepairJob.objects.create(
             job_name="Fix",
             customer=self.customer,
             repair_date=timezone.now(),
             description="d",
-            labor_charge=Decimal("100.00"),
-            parts_cost_total=Decimal("20.00"),
+            total_amount=Decimal("40.00"),
+            status="IN_PROGRESS",
         )
-        self.assertEqual(job.total_amount, Decimal("120.00"))
+        UsedPart.objects.create(repair_job=job, product=self.product, quantity=2)
+        job.save()
+        self.assertEqual(job.parts_cost_total, Decimal("30"))
+        self.assertEqual(job.labor_charge, Decimal("10"))
+
+    def test_zero_labor_when_total_equals_parts_cost(self):
+        job = RepairJob.objects.create(
+            job_name="Fix2",
+            customer=self.customer,
+            repair_date=timezone.now(),
+            description="d",
+            total_amount=Decimal("30.00"),
+            status="IN_PROGRESS",
+        )
+        UsedPart.objects.create(repair_job=job, product=self.product, quantity=2)
+        job.save()
+        self.assertEqual(job.labor_charge, Decimal("0"))
+
+    def test_form_validation_error_when_total_less_than_parts(self):
+        job = RepairJob.objects.create(
+            job_name="Fix3",
+            customer=self.customer,
+            repair_date=timezone.now(),
+            description="d",
+            total_amount=Decimal("20.00"),
+            status="IN_PROGRESS",
+        )
+        UsedPart.objects.create(repair_job=job, product=self.product, quantity=2)
+        form = RepairJobForm(
+            instance=job,
+            data={
+                'job_name': job.job_name,
+                'customer': job.customer.pk,
+                'repair_date': job.repair_date,
+                'description': job.description,
+                'total_amount': Decimal('20.00'),
+                'status': job.status,
+                'notes': job.notes,
+                'payment': job.payment,
+            }
+        )
+        self.assertFalse(form.is_valid())
 
 
 class UsedPartSignalTests(TestCase):
@@ -101,7 +170,7 @@ class UsedPartSignalTests(TestCase):
             customer=self.customer,
             repair_date=timezone.now(),
             description="d",
-            labor_charge=Decimal("50.00"),
+            total_amount=Decimal("95.00"),
             status="COMPLETED",
         )
 
@@ -109,11 +178,13 @@ class UsedPartSignalTests(TestCase):
         part = UsedPart.objects.create(repair_job=self.job, product=self.product, quantity=3)
         part.refresh_from_db()
         self.stock.refresh_from_db()
+        self.job.save()
         self.job.refresh_from_db()
         self.assertEqual(part.cost_price_per_unit, Decimal("15"))
         self.assertEqual(self.stock.current_stock, 7)
         self.assertEqual(self.job.parts_cost_total, Decimal("45"))
         self.assertEqual(self.job.total_amount, Decimal("95.00"))
+        self.assertEqual(self.job.labor_charge, Decimal("50.00"))
 
     def test_used_part_delete_returns_stock(self):
         part = UsedPart.objects.create(repair_job=self.job, product=self.product, quantity=2)
@@ -121,9 +192,11 @@ class UsedPartSignalTests(TestCase):
         self.assertEqual(self.stock.current_stock, 8)
         part.delete()
         self.stock.refresh_from_db()
+        self.job.save()
         self.job.refresh_from_db()
         self.assertEqual(self.stock.current_stock, 10)
         self.assertEqual(self.job.parts_cost_total, Decimal("0"))
+        self.assertEqual(self.job.labor_charge, Decimal("95.00"))
 
     def test_status_change_adjusts_stock(self):
         job = RepairJob.objects.create(
@@ -131,7 +204,7 @@ class UsedPartSignalTests(TestCase):
             customer=self.customer,
             repair_date=timezone.now(),
             description="d",
-            labor_charge=Decimal("0"),
+            total_amount=Decimal("40.00"),
             status="IN_PROGRESS",
         )
         UsedPart.objects.create(repair_job=job, product=self.product, quantity=2)


### PR DESCRIPTION
## Summary
- add helpers to compute parts cost and labor charge
- refactor `RepairJob.save` to use weighted average costs
- add form for user-supplied total amount with validation
- update admin to use new form and show computed fields
- adjust tests and add cases for labor calculations

## Testing
- `python manage.py test repairs.tests --verbosity 2`

------
https://chatgpt.com/codex/tasks/task_e_6846f17741708333aa810da91cab7af0